### PR TITLE
Move to using Echo for Logging

### DIFF
--- a/EasyAPI.cs
+++ b/EasyAPI.cs
@@ -4,10 +4,10 @@ EasyAPI - Documentation: http://steamcommunity.com/sharedfiles/filedetails/?id=3
  
 public class Example : EasyAPI 
 { 
-    public Example(IMyGridTerminalSystem grid, IMyProgrammableBlock me, Action<string> echo) : base(grid, me, echo) 
+    public Example(IMyGridTerminalSystem grid, IMyProgrammableBlock me, Action<string> echo, TimeSpan elapsedTime) : base(grid, me, echo, elapsedTime) 
     { 
         // Start your code here 
-    } 
+    }
 } 
  
  
@@ -21,7 +21,7 @@ void Main(string argument)
 { 
     if(state == null) 
     { 
-        state = new Example(GridTerminalSystem, Me, Echo); 
+        state = new Example(GridTerminalSystem, Me, Echo, ElapsedTime); 
     } 
  
     // Set the minimum time between ticks here to prevent lag. 
@@ -44,6 +44,7 @@ public abstract class EasyAPI
  
     protected IMyGridTerminalSystem GridTerminalSystem; 
     protected Action<string> Echo;
+    protected TimeSpan ElapsedTime;
     static public IMyGridTerminalSystem grid; 
  
     /*** Events ***/ 
@@ -73,13 +74,14 @@ public abstract class EasyAPI
     public const long Years = 365 * Days; 
  
     /*** Constructor ***/ 
-    public EasyAPI(IMyGridTerminalSystem grid, IMyProgrammableBlock me, Action<string> echo) 
+    public EasyAPI(IMyGridTerminalSystem grid, IMyProgrammableBlock me, Action<string> echo, TimeSpan elapsedTime) 
     { 
         this.clock = this.start = DateTime.Now.Ticks; 
         this.delta = 0; 
  
         this.GridTerminalSystem = EasyAPI.grid = grid; 
         this.Echo = echo;
+        this.ElapsedTime = elapsedTime;
         this.ArgumentActions = new Dictionary<string,List<Action>>();
         this.Events = new List<IEasyEvent>(); 
         this.Schedule = new List<EasyInterval>(); 
@@ -1470,12 +1472,47 @@ static public bool EasyCompare(String op, String a, String b)
 /*** Utilities ***/ 
  
 public class EasyUtils { 
-    public static void Log(string logMessage) 
+    public const int LOG_MAX_ECHO_LENGTH_CHARS = 80000; // Mirrored value from MyProgrammableBlock.cs
+    public static StringBuilder LogBuffer;
+    public static void Log(string logMessage, Action<string> echo = null, IMyProgrammableBlock me = null, string label = null) 
     { 
-        String output = "\n"; 
-        output += logMessage; 
-        throw new Exception(output); 
+        String output = "";
+        if(echo == null) {
+            output = "\n"; 
+            output += logMessage; 
+            throw new Exception(output); 
+        }
+        if(LogBuffer == null) {
+            LogBuffer = new StringBuilder();
+        }
+        if(label != null) {
+            logMessage = label+": "+logMessage;
+        }
+        if(LogBuffer.Length == 0) {
+            LogBuffer.Append(logMessage);
+            echo(LogBuffer.ToString());
+            return;
+        }
+        if(LogBuffer.Length > LOG_MAX_ECHO_LENGTH_CHARS) {
+            string[] lines = LogBuffer.ToString().Split('\n');
+            int runningCount = 0;
+            for(int i=0; i<lines.Length; i++) {
+                runningCount += lines[i].Length;
+                if(runningCount > logMessage.Length) {
+                    break;
+                }
+            }
+            output.Substring(runningCount, output.Length - runningCount);
+            LogBuffer.Clear();
+            LogBuffer.Append(output);
+        }
+        LogBuffer.AppendLine();
+        LogBuffer.Append(logMessage);
+        echo(LogBuffer.ToString());
     } 
+    public static void ClearLogBuffer() {
+        LogBuffer.Clear();
+    }
  
     //because "System.array does not contain a definition for .Max()" 
     public static double Max(double[] values) { 
@@ -1494,4 +1531,4 @@ public class EasyUtils {
         } 
         return runningMin; 
     } 
-} 
+}


### PR DESCRIPTION
Update 1.082 has introduced a new method for IMyProgrammableBlock:

Action<string> Echo;

Which will write the string to the Control Panel DetailedInfo area (i.e. where exceptions currently display text), but without throwing an exception and blocking the rest of and any further runs of the script (currently requires recompile to run again).

I'd say it's still warranted to provide an exception throwing mechanism, for times when it is desirable to halt ongoing runs of the script. So need to think of the best places to use Echo in this set:

DebugDump/DebugDumpProperties/DebugDumpActions
EasyUtils.Log

I think using Echo for Log is a no brainer. For DebugDump~, well, it could get messy to use Echo for that. What do you think?
